### PR TITLE
Fix Document file-change regression and add regression test

### DIFF
--- a/lib/dom/document.js
+++ b/lib/dom/document.js
@@ -322,14 +322,15 @@
     };
 
     Document.prototype._updateFile = function (rawFile) {
-        var previousFile = this._file,
+        var raw = typeof rawFile === "string" ? { file: rawFile } : rawFile,
+            previousFile = this._file,
             previousName = this.name,
             previousExtension = this.extension,
             previousDirectory = this.directory,
             previousSaved = this.saved;
 
-        if (previousFile !== rawFile) {
-            this._setFile(rawFile);
+        if (previousFile !== raw.file) {
+            this._setFile(raw);
 
             var change = {
                 previous: previousFile

--- a/test/test-dom-to-raw.js
+++ b/test/test-dom-to-raw.js
@@ -51,4 +51,38 @@
         test.done();
     };
 
+    exports.testFileChangeApplyChange = function (test) {
+        var generator = null,
+            config = null,
+            logger = {
+                warn: function () {},
+                error: function () {}
+            },
+            rawDocinfo = JSON.parse(
+                fs.readFileSync("./test/resources/all-layer-types-docinfo.json", "utf8")
+            ),
+            document = new Document(generator, config, logger, rawDocinfo),
+            originalFile = document.file,
+            changedFile = "/tmp/renamed.psd",
+            fileChangeEvent;
+
+        document.on("file", function (change) {
+            fileChangeEvent = change;
+        });
+
+        var applied = document._applyChange({
+            id: document.id,
+            version: document.version,
+            timeStamp: document.timeStamp + 1,
+            count: document.count + 1,
+            file: changedFile
+        });
+
+        test.strictEqual(applied, true, "Expected file change to apply successfully");
+        test.strictEqual(document.file, changedFile, "Expected file to be updated");
+        test.ok(fileChangeEvent, "Expected file change event to be emitted");
+        test.strictEqual(fileChangeEvent.previous, originalFile, "Expected previous file in change event");
+        test.done();
+    };
+
 }());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes a regression in `Document._updateFile` where `_setFile` now expects a raw object but `_updateFile` still passed a string.
- Ensures docinfo `file`-only change payloads apply successfully without throwing.
- Adds a focused regression test covering `_applyChange` with a `file` change payload.

## Reproduction
- Reproduced on current code by constructing a `Document` from fixture docinfo and applying a `file` change payload.
- Before fix: `_applyChange` returns false and logs `TypeError: The "path" argument must be of type string. Received undefined`.

## Validation plan
- Run `npm test` (includes new regression test) and rerun the direct reproduction command to confirm `_applyChange` now succeeds.

## Risk
- Low: change is constrained to file-change update path and preserves existing behavior for object-shaped inputs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c4bfacf-d27c-45b3-a3a4-c0d36b4caf0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c4bfacf-d27c-45b3-a3a4-c0d36b4caf0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

