### PR TITLE
Append elapsed ms to render-job retry log line

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -512,12 +512,14 @@
             totalAttempts = 1 + this._getRenderRetryMax();
 
         function runAttempt(attemptNumber) {
+            var attemptStart = Date.now();
             return self._renderManager.render(component).then(
                 function (renderResult) {
                     return renderResult;
                 },
                 function (err) {
-                    var waitMs;
+                    var waitMs,
+                        elapsedMs = Date.now() - attemptStart;
 
                     if (!err || err.zeroBoundsError) {
                         return Q.reject(err);
@@ -526,10 +528,11 @@
                         return Q.reject(err);
                     }
                     self._logger.warn(
-                        "Render attempt %d of %d failed for %s: %s; retrying",
+                        "Render attempt %d of %d failed for %s after %dms: %s; retrying",
                         attemptNumber,
                         totalAttempts,
                         component.assetPath,
+                        elapsedMs,
                         err.message
                     );
                     waitMs = _computeRetryWaitMs(self._config, attemptNumber);

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -151,6 +151,52 @@
         am._requestRender({ id: "c1b", assetPath: "out.png", extension: "png" });
     };
 
+    /**
+     * Elapsed ms in the retry warning must reflect Date.now() at attempt start vs failure.
+     * Mock Date.now() so the logged values are deterministic (Miro spec: include elapsed ms).
+     */
+    exports.testRetryWarnLogElapsedMsMatchesDateNowMock = function (test) {
+        var calls = 0;
+        var warns = [];
+        var mockRM = {
+            render: function () {
+                calls++;
+                if (calls < 3) {
+                    return Q.reject(new Error("transient"));
+                }
+                return Q.resolve({ path: "/tmp/asset.png", errors: [] });
+            }
+        };
+        var origNow = Date.now;
+        // Per attempt: attemptStart, then time at failure (two failures, then success).
+        var sequence = [1000, 1042, 2000, 2110, 3000];
+        var seq = 0;
+        Date.now = function () {
+            return sequence[seq++];
+        };
+        var am = makeAssetManager(
+            { "render-retry-max": 2, "render-retry-delay-ms": 0 },
+            mockRM,
+            {
+                warn: function () {
+                    warns.push(Array.prototype.slice.call(arguments));
+                }
+            }
+        );
+        whenIdle(am, function () {
+            try {
+                test.strictEqual(seq, 5, "Date.now should be start+elapsed per failed attempt, then start of success");
+                test.strictEqual(warns.length, 2);
+                test.strictEqual(warns[0][4], 42, "first failure elapsed ms");
+                test.strictEqual(warns[1][4], 110, "second failure elapsed ms");
+            } finally {
+                Date.now = origNow;
+            }
+            test.done();
+        });
+        am._requestRender({ id: "c1c", assetPath: "out.png", extension: "png" });
+    };
+
     exports.testNoRetryWhenMaxIsZero = function (test) {
         var calls = 0;
         var mockRM = {

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -133,14 +133,18 @@
 
         whenIdle(am, function () {
             test.strictEqual(warns.length, 2, "one warn before each retry");
-            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying");
+            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s after %dms: %s; retrying");
             test.strictEqual(warns[0][1], 1);
             test.strictEqual(warns[0][2], 3);
             test.strictEqual(warns[0][3], "out.png");
-            test.strictEqual(warns[0][4], "transient");
+            test.strictEqual(typeof warns[0][4], "number", "elapsed ms should be a number");
+            test.ok(warns[0][4] >= 0, "elapsed ms should be non-negative");
+            test.strictEqual(warns[0][5], "transient");
             test.strictEqual(warns[1][1], 2);
             test.strictEqual(warns[1][2], 3);
-            test.strictEqual(warns[1][4], "transient");
+            test.strictEqual(typeof warns[1][4], "number", "elapsed ms should be a number");
+            test.ok(warns[1][4] >= 0, "elapsed ms should be non-negative");
+            test.strictEqual(warns[1][5], "transient");
             test.done();
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue #15 validation

This branch implements the Generator Assets Miro-board feature: **elapsed milliseconds on the render-retry warning log** (`lib/assetmanager.js`), with tests in `test/test-render-retry.js`.

### Latest change
- Added `testRetryWarnLogElapsedMsMatchesDateNowMock`, which mocks `Date.now` with a controlled sequence so the warn log’s `%dms` argument is asserted exactly (42 and 110 for two failures), and verifies call count. The mock is restored in the `idle` handler so it does not race async retry work.

### Verification
- `npm test` and `grunt build test` pass on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52f5ff77-85df-4c51-b40a-9c508d3363a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52f5ff77-85df-4c51-b40a-9c508d3363a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

