### PR TITLE
Append elapsed ms to render-job retry log line

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -512,12 +512,14 @@
             totalAttempts = 1 + this._getRenderRetryMax();
 
         function runAttempt(attemptNumber) {
+            var attemptStart = Date.now();
             return self._renderManager.render(component).then(
                 function (renderResult) {
                     return renderResult;
                 },
                 function (err) {
-                    var waitMs;
+                    var waitMs,
+                        elapsedMs = Math.max(0, Date.now() - attemptStart);
 
                     if (!err || err.zeroBoundsError) {
                         return Q.reject(err);
@@ -526,11 +528,12 @@
                         return Q.reject(err);
                     }
                     self._logger.warn(
-                        "Render attempt %d of %d failed for %s: %s; retrying",
+                        "Render attempt %d of %d failed for %s: %s; retrying (elapsed %d ms)",
                         attemptNumber,
                         totalAttempts,
                         component.assetPath,
-                        err.message
+                        err.message,
+                        elapsedMs
                     );
                     waitMs = _computeRetryWaitMs(self._config, attemptNumber);
                     return Q.delay(waitMs).then(function () {

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -151,6 +151,57 @@
         am._requestRender({ id: "c1b", assetPath: "out.png", extension: "png" });
     };
 
+    /**
+     * Elapsed ms in the warn line must reflect wall time from attempt start to failure
+     * (Miro feature: per-attempt duration in the retry log).
+     */
+    exports.testRetryWarnElapsedMsMatchesAttemptDuration = function (test) {
+        var calls = 0;
+        var warns = [];
+        var mockRM = {
+            render: function () {
+                calls++;
+                if (calls < 3) {
+                    return Q.reject(new Error("transient"));
+                }
+                return Q.resolve({ path: "/tmp/asset.png", errors: [] });
+            }
+        };
+
+        var origNow = Date.now;
+        var nowIdx = 0;
+        // Two failures: start at 5000 then 5150 (150 ms "work"); second 9000 -> 9300 (300 ms).
+        // Third attempt succeeds after one Date.now at attempt start (10000).
+        var nowSequence = [5000, 5150, 9000, 9300, 10000];
+        Date.now = function () {
+            return nowSequence[nowIdx++];
+        };
+
+        var am = makeAssetManager(
+            { "render-retry-max": 2, "render-retry-delay-ms": 0 },
+            mockRM,
+            {
+                warn: function () {
+                    warns.push(Array.prototype.slice.call(arguments));
+                }
+            }
+        );
+
+        whenIdle(am, function () {
+            try {
+                test.strictEqual(nowIdx, 5, "Date.now: two per failed attempt plus one at successful attempt start");
+                test.strictEqual(warns.length, 2);
+                test.strictEqual(warns[0][5], 150);
+                test.strictEqual(warns[1][5], 300);
+            } finally {
+                Date.now = origNow;
+            }
+            test.done();
+        });
+
+        am._requestRender({ id: "c1c", assetPath: "out.png", extension: "png" });
+    };
+
     exports.testNoRetryWhenMaxIsZero = function (test) {
         var calls = 0;
         var mockRM = {

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -133,14 +133,18 @@
 
         whenIdle(am, function () {
             test.strictEqual(warns.length, 2, "one warn before each retry");
-            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying");
+            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying (elapsed %d ms)");
             test.strictEqual(warns[0][1], 1);
             test.strictEqual(warns[0][2], 3);
             test.strictEqual(warns[0][3], "out.png");
             test.strictEqual(warns[0][4], "transient");
+            test.strictEqual(typeof warns[0][5], "number");
+            test.ok(warns[0][5] >= 0, "elapsed ms should be non-negative");
             test.strictEqual(warns[1][1], 2);
             test.strictEqual(warns[1][2], 3);
             test.strictEqual(warns[1][4], "transient");
+            test.strictEqual(typeof warns[1][5], "number");
+            test.ok(warns[1][5] >= 0, "elapsed ms should be non-negative");
             test.done();
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **"Micro feature"** described on the [Generator-Assets Miro board](https://miro.com/app/board/uXjVGh30cYM=/?share_link_id=69029770709):

> Append **elapsed ms** to the existing render-job retry log line.

## Changes

- `lib/assetmanager.js` — `runAttempt` records `Date.now()` at the start of each render attempt and includes per-attempt elapsed wall-clock milliseconds in the retry warn log:
  - Before: `Render attempt %d of %d failed for %s: %s; retrying`
  - After:  `Render attempt %d of %d failed for %s: %s; retrying (elapsed %d ms)`
- `test/test-render-retry.js` — `testRetryLogsWarnBeforeEachRetry` asserts the new format and a non-negative numeric elapsed argument; **`testRetryWarnElapsedMsMatchesAttemptDuration`** stubs `Date.now()` so elapsed values are checked against the time from attempt start to failure.

The `elapsedMs` value is clamped to `>= 0` to be defensive against any clock skew.

## Verification

Full CI pipeline: `grunt build test` — **232** assertions passed (JSHint, JSCS, nodeunit).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96b1a33f-ad53-49e3-856a-f29983eb1ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96b1a33f-ad53-49e3-856a-f29983eb1ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

