### PR TITLE
test: issue #19 — validate render retry elapsed-ms logging

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -512,12 +512,14 @@
             totalAttempts = 1 + this._getRenderRetryMax();
 
         function runAttempt(attemptNumber) {
+            var attemptStart = Date.now();
             return self._renderManager.render(component).then(
                 function (renderResult) {
                     return renderResult;
                 },
                 function (err) {
-                    var waitMs;
+                    var waitMs,
+                        elapsedMs = Date.now() - attemptStart;
 
                     if (!err || err.zeroBoundsError) {
                         return Q.reject(err);
@@ -526,11 +528,12 @@
                         return Q.reject(err);
                     }
                     self._logger.warn(
-                        "Render attempt %d of %d failed for %s: %s; retrying",
+                        "Render attempt %d of %d failed for %s: %s; retrying (elapsed %d ms)",
                         attemptNumber,
                         totalAttempts,
                         component.assetPath,
-                        err.message
+                        err.message,
+                        elapsedMs
                     );
                     waitMs = _computeRetryWaitMs(self._config, attemptNumber);
                     return Q.delay(waitMs).then(function () {

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -151,6 +151,51 @@
         am._requestRender({ id: "c1b", assetPath: "out.png", extension: "png" });
     };
 
+    /**
+     * Elapsed ms in the warn line must match Date.now() deltas for each failed attempt
+     * (deterministic with a stubbed clock).
+     */
+    exports.testRetryWarnElapsedMsMatchesAttemptDuration = function (test) {
+        var calls = 0;
+        var warns = [];
+        var mockRM = {
+            render: function () {
+                calls++;
+                if (calls < 3) {
+                    return Q.reject(new Error("transient"));
+                }
+                return Q.resolve({ path: "/tmp/asset.png", errors: [] });
+            }
+        };
+        var seq = [1000, 1042, 2000, 2150, 3000];
+        var i = 0;
+        var origNow = Date.now;
+        Date.now = function () {
+            return seq[i++];
+        };
+
+        var am = makeAssetManager(
+            { "render-retry-max": 2, "render-retry-delay-ms": 0 },
+            mockRM,
+            {
+                warn: function () {
+                    warns.push(Array.prototype.slice.call(arguments));
+                }
+            }
+        );
+
+        whenIdle(am, function () {
+            Date.now = origNow;
+            test.strictEqual(warns.length, 2);
+            test.strictEqual(warns[0][5], 42, "first failure: 1042 - 1000");
+            test.strictEqual(warns[1][5], 150, "second failure: 2150 - 2000");
+            test.strictEqual(i, 5, "Date.now should be start+end for two failures, start for success");
+            test.done();
+        });
+
+        am._requestRender({ id: "c1c", assetPath: "out.png", extension: "png" });
+    };
+
     exports.testNoRetryWhenMaxIsZero = function (test) {
         var calls = 0;
         var mockRM = {

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -133,14 +133,18 @@
 
         whenIdle(am, function () {
             test.strictEqual(warns.length, 2, "one warn before each retry");
-            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying");
+            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying (elapsed %d ms)");
             test.strictEqual(warns[0][1], 1);
             test.strictEqual(warns[0][2], 3);
             test.strictEqual(warns[0][3], "out.png");
             test.strictEqual(warns[0][4], "transient");
+            test.strictEqual(typeof warns[0][5], "number");
+            test.ok(warns[0][5] >= 0, "elapsed ms should be non-negative");
             test.strictEqual(warns[1][1], 2);
             test.strictEqual(warns[1][2], 3);
             test.strictEqual(warns[1][4], "transient");
+            test.strictEqual(typeof warns[1][5], "number");
+            test.ok(warns[1][5] >= 0, "elapsed ms should be non-negative");
             test.done();
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a deterministic unit test for the issue #19 / Miro-board feature: the render retry warning includes elapsed milliseconds that match `Date.now()` deltas per failed attempt (using a stubbed clock).

## Testing

- `npm test`
- `npx grunt test` (jshint, jscs, nodeunit)

All passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc576ac5-0703-4856-a0b9-b74510e3c9ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc576ac5-0703-4856-a0b9-b74510e3c9ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

