### PR TITLE
Issue #24: Log elapsed ms on render retry warnings

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -512,12 +512,14 @@
             totalAttempts = 1 + this._getRenderRetryMax();
 
         function runAttempt(attemptNumber) {
+            var attemptStart = Date.now();
             return self._renderManager.render(component).then(
                 function (renderResult) {
                     return renderResult;
                 },
                 function (err) {
-                    var waitMs;
+                    var waitMs,
+                        elapsedMs = Date.now() - attemptStart;
 
                     if (!err || err.zeroBoundsError) {
                         return Q.reject(err);
@@ -526,11 +528,12 @@
                         return Q.reject(err);
                     }
                     self._logger.warn(
-                        "Render attempt %d of %d failed for %s: %s; retrying",
+                        "Render attempt %d of %d failed for %s: %s; retrying (elapsed %dms)",
                         attemptNumber,
                         totalAttempts,
                         component.assetPath,
-                        err.message
+                        err.message,
+                        elapsedMs
                     );
                     waitMs = _computeRetryWaitMs(self._config, attemptNumber);
                     return Q.delay(waitMs).then(function () {

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -133,14 +133,19 @@
 
         whenIdle(am, function () {
             test.strictEqual(warns.length, 2, "one warn before each retry");
-            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying");
+            test.strictEqual(
+                warns[0][0],
+                "Render attempt %d of %d failed for %s: %s; retrying (elapsed %dms)"
+            );
             test.strictEqual(warns[0][1], 1);
             test.strictEqual(warns[0][2], 3);
             test.strictEqual(warns[0][3], "out.png");
             test.strictEqual(warns[0][4], "transient");
+            test.ok(typeof warns[0][5] === "number" && warns[0][5] >= 0, "elapsed ms is non-negative");
             test.strictEqual(warns[1][1], 2);
             test.strictEqual(warns[1][2], 3);
             test.strictEqual(warns[1][4], "transient");
+            test.ok(typeof warns[1][5] === "number" && warns[1][5] >= 0, "elapsed ms is non-negative");
             test.done();
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds elapsed time (milliseconds) to render-job retry warning logs in `lib/assetmanager.js` so transient failures are easier to correlate with timing.

## Tests

- Updated `test/test-render-retry.js` (`testRetryLogsWarnBeforeEachRetry`) for the new warn format and extra `elapsedMs` argument.
- Ran: `node node_modules/.bin/nodeunit test/test-render-retry.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38942ee2-bffc-4cc7-a8e8-cce609954967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38942ee2-bffc-4cc7-a8e8-cce609954967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

