### PR TITLE
Issue #34: render retry log elapsed ms + test alignment

### DIFF
--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -512,12 +512,14 @@
             totalAttempts = 1 + this._getRenderRetryMax();
 
         function runAttempt(attemptNumber) {
+            var attemptStart = Date.now();
             return self._renderManager.render(component).then(
                 function (renderResult) {
                     return renderResult;
                 },
                 function (err) {
-                    var waitMs;
+                    var waitMs,
+                        elapsedMs = Date.now() - attemptStart;
 
                     if (!err || err.zeroBoundsError) {
                         return Q.reject(err);
@@ -526,11 +528,12 @@
                         return Q.reject(err);
                     }
                     self._logger.warn(
-                        "Render attempt %d of %d failed for %s: %s; retrying",
+                        "Render attempt %d of %d failed for %s: %s; retrying (elapsed %d ms)",
                         attemptNumber,
                         totalAttempts,
                         component.assetPath,
-                        err.message
+                        err.message,
+                        elapsedMs
                     );
                     waitMs = _computeRetryWaitMs(self._config, attemptNumber);
                     return Q.delay(waitMs).then(function () {

--- a/test/test-render-retry.js
+++ b/test/test-render-retry.js
@@ -133,14 +133,16 @@
 
         whenIdle(am, function () {
             test.strictEqual(warns.length, 2, "one warn before each retry");
-            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying");
+            test.strictEqual(warns[0][0], "Render attempt %d of %d failed for %s: %s; retrying (elapsed %d ms)");
             test.strictEqual(warns[0][1], 1);
             test.strictEqual(warns[0][2], 3);
             test.strictEqual(warns[0][3], "out.png");
             test.strictEqual(warns[0][4], "transient");
+            test.ok(typeof warns[0][5] === "number" && warns[0][5] >= 0, "elapsed ms for first failed attempt");
             test.strictEqual(warns[1][1], 2);
             test.strictEqual(warns[1][2], 3);
             test.strictEqual(warns[1][4], "transient");
+            test.ok(typeof warns[1][5] === "number" && warns[1][5] >= 0, "elapsed ms for second failed attempt");
             test.done();
         });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The feature branch adds elapsed time to the render-retry warning in `lib/assetmanager.js`. This change updates `test/test-render-retry.js` so expectations match the new log format and lightly asserts the elapsed-ms argument.

## Tests

```bash
node node_modules/.bin/nodeunit test/test-render-retry.js
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b78bf261-3f14-4485-8c61-d984128584ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b78bf261-3f14-4485-8c61-d984128584ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

